### PR TITLE
add QCDT support

### DIFF
--- a/verify_signature.py
+++ b/verify_signature.py
@@ -54,7 +54,8 @@ class androidboot:
     second_size=0
     tags_addr=0
     page_size=0
-    unused=0
+    qcdt_size=0
+    qcdt_addr=0
     os_version=0
     name="" #BOOT_NAME_SIZE 16
     cmdline="" #BOOT_ARGS_SIZE 512
@@ -65,7 +66,7 @@ def getheader(inputfile):
     param = androidboot()
     with open(inputfile, 'rb') as rf:
         header = rf.read(0x660)
-        fields = struct.unpack('<8sIIIIIIIIII16s512s8I1024s', header)
+        fields = struct.unpack('<8sIIIIIIIIIIII8s512s8I1024s', header)
         param.magic = fields[0]
         param.kernel_size = fields[1]
         param.kernel_addr = fields[2]
@@ -75,12 +76,13 @@ def getheader(inputfile):
         param.second_addr = fields[6]
         param.tags_addr = fields[7]
         param.page_size = fields[8]
-        param.unused = fields[9]
-        param.os_version = fields[10]
-        param.name = fields[11]
-        param.cmdline = fields[12]
-        param.id = [fields[13],fields[14],fields[15],fields[16],fields[17],fields[18],fields[19],fields[20]]
-        param.extra_cmdline = fields[21]
+        param.qcdt_size = fields[9]
+        param.qcdt_addr = fields[10]
+        param.os_version = fields[11]
+        param.name = fields[12]
+        param.cmdline = fields[13]
+        param.id = [fields[14],fields[15],fields[16],fields[17],fields[18],fields[19],fields[20],fields[21]]
+        param.extra_cmdline = fields[22]
     return param
 
 def int_to_bytes(x):
@@ -97,10 +99,13 @@ def main(argv):
     kernelsize = int((param.kernel_size + param.page_size - 1) / param.page_size) * param.page_size
     ramdisksize = int((param.ramdisk_size + param.page_size - 1) / param.page_size) * param.page_size
     secondsize = int((param.second_size + param.page_size - 1) / param.page_size) * param.page_size
+    qcdtsize = int((param.qcdt_size + param.page_size - 1) / param.page_size) * param.page_size
+
     print("Kernel=0x%08X, length=0x%08X" % (param.page_size, kernelsize))
     print("Ramdisk=0x%08X, length=0x%08X" % ((param.page_size+kernelsize),ramdisksize))
     print("Second=0x%08X, length=0x%08X" % ((param.page_size+kernelsize+ramdisksize),secondsize))
-    length=param.page_size+kernelsize+ramdisksize+secondsize
+    print("QCDT=0x%08X, length=0x%08X" % ((param.page_size+kernelsize+ramdisksize+secondsize),qcdtsize))
+    length=param.page_size+kernelsize+ramdisksize+secondsize+qcdtsize
     print("Signature start=0x%08X" % length)
     sha256=hashlib.sha256()
     with open(filename,'rb') as fr:


### PR DESCRIPTION
```$ python3 verify_signature.py ../boot_458752.bin

Dump Android Verified Boot Signature (c) B.Kerler 2017
------------------------------------------------------
Kernel=0x00001000, length=0x012C1000
Ramdisk=0x012C2000, length=0x004DD000
Second=0x0179F000, length=0x00000000
QCDT=0x0179F000, length=0x0008E000
Signature start=0x0182D000

Image-Target: b'/boot'
Image-Length: 0x182d000

Image-Hash: b'00810604dac25e8fbbf23eb0e446fbaf485f6b89cf09eef95f85cdc0a3e60312'
Signature-Hash: b'1d39e66a1152bb0b82ce01a8b61179b894615700fd867f57583eb322fb07af14'

Signature-RSA-Modulus (n): b'c210e84edf25fecc61c1783766b8fd72e26a2ad044401187c5faab9669811266d7d64f59d5bd2f207e6f19ab94421c5cf6fa319023c426df857cf97a05692eb828efd5c8112f3c8cf30c1e497285b0d8a57d195b89016b6718da68bf71372a7c37e160dffdf6d322088ce9e09c4d6b957f3d70ebaa15a69ec164943c4d0f1c495332cf170fd6a3416b70f5cdd6e40b77b02bd060062fb044077ac6ad4c25fa2bd644f2611dfa8dd7974089427ee1f27eea3f38f6c1cd4b26641a1760b98b25be4c20477f156e6380ba0b8749008a01ff61408f6e11ffa369205f1311b71352f889a2be7b737fd9b50a1b63c2465ba2990dea4eeabee70dabba6c9ca80f4b4ea5'
Signature-RSA-Exponent (e): b'010001'

TZ Root of trust (locked): b'dd77957b0e16dcc5f88f2fbb2c1890da664d241ab42cbd4e28afe2aed2dc32dc'
TZ Root of trust (unlocked): b'b9abcedb380dd6991882ce511299419c1e5c0a32d766232b7a0b78cd6550c9c8'```